### PR TITLE
Add slug routes for gallery and enhance photo viewer

### DIFF
--- a/src/app/(frontend)/gallery/[slug]/page.tsx
+++ b/src/app/(frontend)/gallery/[slug]/page.tsx
@@ -1,0 +1,20 @@
+import { sanityFetch } from "@/sanity/lib/live";
+import { ALBUM_BY_SLUG_QUERY } from "@/sanity/lib/queries";
+import { Album } from "@/sanity/types";
+import { notFound } from "next/navigation";
+import AlbumViewer from "@/components/album-viewer";
+
+export default async function AlbumPage({ params }: { params: { slug: string } }) {
+  const { slug } = params;
+  const result = await sanityFetch<{ data: Album | null }>({
+    query: ALBUM_BY_SLUG_QUERY,
+    params: { slug },
+  });
+
+  const album = result.data;
+  if (!album) {
+    notFound();
+  }
+
+  return <AlbumViewer photos={album.images || []} title={album.title} />;
+}

--- a/src/app/(frontend)/gallery/page.tsx
+++ b/src/app/(frontend)/gallery/page.tsx
@@ -25,6 +25,7 @@ export default async function GalleryPage() {
           <PhotoAlbum
             key={album._id}
             title={album.title}
+            slug={album.slug}
             albumDate={album.albumDate}
             description={album.description}
             images={album.images}

--- a/src/components/album-viewer.tsx
+++ b/src/components/album-viewer.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useRouter } from "next/navigation";
+import PhotoViewer from "./photo-viewer";
+import { type Image as SanityImage } from "sanity";
+
+interface SanityPhoto extends SanityImage {
+  caption?: string;
+  alt?: string;
+  description?: string;
+}
+
+export default function AlbumViewer({ photos, title }: { photos: SanityPhoto[]; title?: string }) {
+  const router = useRouter();
+  return (
+    <PhotoViewer
+      photos={photos}
+      initialIndex={0}
+      onClose={() => router.push("/gallery")}
+      title={title}
+    />
+  );
+}

--- a/src/components/photo-album.tsx
+++ b/src/components/photo-album.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { useState } from "react"
 import Image from "next/image"
+import Link from "next/link"
 import { CalendarDays } from "lucide-react";
 import createImageUrlBuilder from '@sanity/image-url';
 import { client } from '@/sanity/lib/client'; // Assuming your client is exported from this path
-import PhotoViewer from "./photo-viewer"
 import { type Image as SanityImage } from 'sanity'; // Import Sanity's Image type
 import { formatEventDate } from "@/lib/date-utils";
 
@@ -17,24 +16,19 @@ interface SanityPhoto extends SanityImage {
 
 interface PhotoAlbumProps {
   title: string
+  slug: string
   albumDate: string // Changed from 'date' to 'albumDate' to match schema
   description?: string // Made optional as per schema
   images?: SanityPhoto[] // Use SanityPhoto array
 }
 
-export default function PhotoAlbum({ title, albumDate, description, images: photos }: PhotoAlbumProps) {
-  const [viewerOpen, setViewerOpen] = useState(false)
-  const [initialPhotoIndex, setInitialPhotoIndex] = useState(0)
+export default function PhotoAlbum({ title, slug, albumDate, description, images: photos }: PhotoAlbumProps) {
 
   // Add a check to ensure photos is an array before proceeding
   if (!Array.isArray(photos) || photos.length === 0) {
     return null // Or return <div />; depending on desired behavior for albums with no photos
   }
 
-  const openViewer = (index: number) => {
-    setInitialPhotoIndex(index)
-    setViewerOpen(true)
-  }
 
   // Create image URL builder instance
   const builder = createImageUrlBuilder(client);
@@ -47,12 +41,14 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
   const displayPhotos = photos.slice(0, Math.min(5, photos.length));
   const remainingCount = photos.length - displayPhotos.length;
 
+  const albumUrl = `/gallery/${slug}`;
+
   return (
-    <div className="mb-6 overflow-hidden rounded-xl border bg-card shadow-sm">
+    <Link href={albumUrl} className="block mb-6 overflow-hidden rounded-xl border bg-card shadow-sm">
       <div className="p-4">
         <div className="mb-2 flex items-center gap-2 text-sm font-medium text-primary">
           <CalendarDays className="h-4 w-4" />
-          <span>{formatEventDate(albumDate)}</span> {}
+          <span>{formatEventDate(albumDate)}</span>
         </div>
         <h2 className="mb-2 text-xl font-bold">{title}</h2>
         <p className="mb-4 text-sm text-muted-foreground line-clamp-2">{description}</p>
@@ -62,8 +58,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
         {displayPhotos.length === 2 && (
           <>
             <div
-              className="col-span-2 row-span-2 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(0)}
+              className="col-span-2 row-span-2 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[0]).width(300).url() || "/placeholder.svg"}
@@ -73,8 +68,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-2 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(1)}
+              className="col-span-1 row-span-2 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[1]).width(300).url() || "/placeholder.svg"}
@@ -89,8 +83,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
         {displayPhotos.length === 3 && (
           <>
             <div
-              className="col-span-3 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(0)}
+              className="col-span-3 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[0]).width(300).url() || "/placeholder.svg"}
@@ -100,8 +93,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(1)}
+              className="col-span-1 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[1]).width(300).url() || "/placeholder.svg"}
@@ -111,8 +103,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-2 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(2)}
+              className="col-span-2 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[2]).width(300).url() || "/placeholder.svg"}
@@ -127,8 +118,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
         {displayPhotos.length === 4 && (
           <>
             <div
-              className="col-span-2 row-span-2 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(0)}
+              className="col-span-2 row-span-2 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[0]).width(300).url() || "/placeholder.svg"}
@@ -138,8 +128,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(1)}
+              className="col-span-1 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[1]).width(300).url() || "/placeholder.svg"}
@@ -149,8 +138,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(2)}
+              className="col-span-1 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[2]).width(300).url() || "/placeholder.svg"}
@@ -165,8 +153,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
         {displayPhotos.length >= 5 && (
           <>
             <div
-              className="col-span-2 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(0)}
+              className="col-span-2 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[0]).width(300).url() || "/placeholder.svg"}
@@ -176,8 +163,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(1)}
+              className="col-span-1 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[1]).width(300).url() || "/placeholder.svg"}
@@ -187,8 +173,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(2)}
+              className="col-span-1 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[2]).width(300).url() || "/placeholder.svg"}
@@ -198,8 +183,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(3)}
+              className="col-span-1 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[3]).width(300).url() || "/placeholder.svg"}
@@ -209,8 +193,7 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
               />
             </div>
             <div
-              className="col-span-1 row-span-1 relative cursor-pointer overflow-hidden"
-              onClick={() => openViewer(4)}
+              className="col-span-1 row-span-1 relative overflow-hidden"
             >
               <Image
                 src={urlFor(displayPhotos[4]).width(300).url() || "/placeholder.svg"}
@@ -228,14 +211,6 @@ export default function PhotoAlbum({ title, albumDate, description, images: phot
         )}
       </div>
 
-      {viewerOpen && (
-        <PhotoViewer
-          photos={photos} // Pass the original images array to PhotoViewer
-          initialIndex={initialPhotoIndex}
-          onClose={() => setViewerOpen(false)}
-          title={title}
-        />
-      )}
-    </div>
+    </Link>
   )
 }

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Image from "next/image";
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
 import createImageUrlBuilder from "@sanity/image-url";
@@ -27,6 +27,7 @@ export default function PhotoViewer({
 }: PhotoViewerProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [isLoading, setIsLoading] = useState(true);
+  const touchStartX = useRef<number | null>(null);
 
   const builder = createImageUrlBuilder(client);
   function urlFor(source: SanityPhoto) {
@@ -61,6 +62,26 @@ export default function PhotoViewer({
   }, []);
 
   useEffect(() => {
+    const handleTouchStart = (e: TouchEvent) => {
+      touchStartX.current = e.touches[0].clientX;
+    };
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (touchStartX.current === null) return;
+      const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+      if (Math.abs(deltaX) > 50) {
+        if (deltaX > 0) navigatePrev();
+        else navigateNext();
+      }
+    };
+    window.addEventListener("touchstart", handleTouchStart);
+    window.addEventListener("touchend", handleTouchEnd);
+    return () => {
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [navigatePrev, navigateNext]);
+
+  useEffect(() => {
     setIsLoading(true);
   }, [currentIndex]);
 
@@ -77,12 +98,6 @@ export default function PhotoViewer({
         <X className="h-6 w-6" />
       </button>
 
-      {/* Counter */}
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[110] text-white">
-        <p className="text-sm text-center text-gray-300">
-          {currentIndex + 1} of {photos.length}
-        </p>
-      </div>
 
       {/* Navigation */}
       <button
@@ -115,20 +130,20 @@ export default function PhotoViewer({
             onLoad={() => setIsLoading(false)}
           />
 
-          {/* Caption & Description band */}
-          {(currentPhoto.caption || currentPhoto.description) && (
-            <div className="absolute bottom-0 left-0 w-full bg-black/60 p-4 text-white backdrop-blur-sm">
-              {currentPhoto.caption && (
-                <h3 className="text-lg font-semibold mb-1">
-                  {currentPhoto.caption}
-                </h3>
-              )}
-              {currentPhoto.description && (
-                <p className="text-sm">{currentPhoto.description}</p>
-              )}
-            </div>
-          )}
         </div>
+      </div>
+
+      {/* Info below image */}
+      <div className="mt-4 text-center text-white">
+        <p className="text-sm mb-1 text-gray-300">
+          {currentIndex + 1} of {photos.length}
+        </p>
+        {currentPhoto.caption && (
+          <h3 className="text-lg font-semibold">{currentPhoto.caption}</h3>
+        )}
+        {currentPhoto.description && (
+          <p className="text-sm mt-1">{currentPhoto.description}</p>
+        )}
       </div>
     </div>
   );

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -61,7 +61,24 @@ export const EVENT_BY_SLUG_QUERY = defineQuery(`
 export const GALLERY_ALBUMS_QUERY = `*[_type == "album"] {
   _id,
   title,
-  slug,
+  "slug": slug.current,
+  description,
+  albumDate,
+  images[]{
+    _key,
+    asset->{url},
+    hotspot,
+    crop,
+    caption,
+    alt,
+    description
+  }
+}`;
+
+export const ALBUM_BY_SLUG_QUERY = `*[_type == "album" && slug.current == $slug][0]{
+  _id,
+  title,
+  "slug": slug.current,
   description,
   albumDate,
   images[]{


### PR DESCRIPTION
## Summary
- link gallery cards to new slug-based routes
- fetch single albums by slug
- show album photos using new AlbumViewer wrapper
- display caption and counts below image, remove overlay
- enable swipe navigation in photo viewer

## Testing
- `npm run build` *(fails: Missing environment variable NEXT_PUBLIC_SANITY_DATASET)*