### PR TITLE
Enable email sending from contact form

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/src/app/(frontend)/contact/page.tsx
+++ b/src/app/(frontend)/contact/page.tsx
@@ -26,21 +26,24 @@ export default function ContactPage() {
     setFormState((prev) => ({ ...prev, [name]: value }))
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsSubmitting(true)
 
-    // Simulate form submission
-    setTimeout(() => {
-      setIsSubmitting(false)
-      setIsSubmitted(true)
-      setFormState({
-        name: "",
-        email: "",
-        subject: "",
-        message: "",
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formState),
       })
-    }, 1500)
+
+      if (res.ok) {
+        setIsSubmitted(true)
+        setFormState({ name: "", email: "", subject: "", message: "" })
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import nodemailer from "nodemailer";
+
+export async function POST(req: Request) {
+  try {
+    const { name, email, subject, message } = await req.json();
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT || 587),
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: process.env.SMTP_USER,
+      to: process.env.SMTP_USER,
+      subject: `[Contact] ${subject}`,
+      text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- use nodemailer on an API route to deliver contact form emails
- call the new API route from the contact page
- add nodemailer dependency to package.json

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, react/no-unescaped-entities, etc.)*