### PR TITLE
Use react-photo-view for gallery images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.54.1",
         "react-resizable-panels": "^2.1.7",
+        "react-photo-view": "^1.2.3",
         "react-zoom-pan-pinch": "^3.7.0",
         "recharts": "2.15.0",
         "sanity": "^3.87.1",
@@ -17171,6 +17172,16 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/react-photo-view": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/react-photo-view/-/react-photo-view-1.2.3.tgz",
+      "integrity": "sha512-dtaFjU8nAB/rD8mxBaaJcvESlDOweAd1tmvXujS/d3oh1QyGew3xD4C02l46E6Dhn3Tshzl2+IM1h0MWV9nG7g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^2.1.7",
+    "react-photo-view": "^1.2.3",
     "react-zoom-pan-pinch": "^3.7.0",
     "recharts": "2.15.0",
     "sanity": "^3.87.1",

--- a/src/app/(frontend)/gallery/[slug]/page.tsx
+++ b/src/app/(frontend)/gallery/[slug]/page.tsx
@@ -16,5 +16,10 @@ export default async function AlbumPage({ params }: { params: { slug: string } }
     notFound();
   }
 
-  return <AlbumViewer photos={album.images || []} title={album.title} />;
+  return (
+    <div className="container py-12">
+      <h1 className="mb-6 text-3xl font-bold">{album.title}</h1>
+      <AlbumViewer photos={album.images || []} />
+    </div>
+  );
 }

--- a/src/app/(frontend)/gallery/gallery.css
+++ b/src/app/(frontend)/gallery/gallery.css
@@ -51,22 +51,3 @@
   grid-row: span 1;
 }
 
-.photo-viewer-backdrop {
-  background-color: rgba(0, 0, 0, 0.9);
-  backdrop-filter: blur(5px);
-}
-
-.photo-viewer-image {
-  max-height: 90vh;
-  max-width: 90vw;
-  object-fit: contain;
-}
-
-.photo-viewer-controls {
-  opacity: 0;
-  transition: opacity 200ms ease;
-}
-
-.photo-viewer:hover .photo-viewer-controls {
-  opacity: 1;
-}

--- a/src/components/album-viewer.tsx
+++ b/src/components/album-viewer.tsx
@@ -1,22 +1,54 @@
 "use client";
-import { useRouter } from "next/navigation";
-import PhotoViewer from "./photo-viewer";
+
+import { useState } from "react";
+import Image from "next/image";
+import { PhotoProvider } from "react-photo-view";
+import "react-photo-view/dist/react-photo-view.css";
+import createImageUrlBuilder from "@sanity/image-url";
+import { client } from "@/sanity/lib/client";
 import { type Image as SanityImage } from "sanity";
+import PhotoViewer from "./photo-viewer";
 
 interface SanityPhoto extends SanityImage {
-  caption?: string;
   alt?: string;
-  description?: string;
 }
 
-export default function AlbumViewer({ photos, title }: { photos: SanityPhoto[]; title?: string }) {
-  const router = useRouter();
+export default function AlbumViewer({ photos }: { photos: SanityPhoto[] }) {
+  const [index, setIndex] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  const builder = createImageUrlBuilder(client);
+
   return (
-    <PhotoViewer
-      photos={photos}
-      initialIndex={0}
-      onClose={() => router.push("/gallery")}
-      title={title}
-    />
+    <PhotoProvider>
+      <div className="container py-12">
+        <div className="grid gap-2 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+          {photos.map((photo, i) => (
+            <div
+              key={photo._key ?? i}
+              className="relative aspect-square cursor-pointer overflow-hidden"
+              onClick={() => {
+                setIndex(i);
+                setVisible(true);
+              }}
+            >
+              <Image
+                src={builder.image(photo).width(400).height(400).url() || "/placeholder.svg"}
+                alt={photo.alt ?? ""}
+                fill
+                className="object-cover"
+              />
+            </div>
+          ))}
+        </div>
+        <PhotoViewer
+          photos={photos}
+          visible={visible}
+          index={index}
+          onClose={() => setVisible(false)}
+          onIndexChange={setIndex}
+        />
+      </div>
+    </PhotoProvider>
   );
 }

--- a/src/components/photo-album.tsx
+++ b/src/components/photo-album.tsx
@@ -9,9 +9,7 @@ import { type Image as SanityImage } from 'sanity'; // Import Sanity's Image typ
 import { formatEventDate } from "@/lib/date-utils";
 
 interface SanityPhoto extends SanityImage {
-  caption?: string;
   alt?: string;
-  description?: string;
 }
 
 interface PhotoAlbumProps {

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -1,150 +1,40 @@
-"use client"
+"use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
-import Image from "next/image";
-import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import { PhotoProvider, PhotoSlider } from "react-photo-view";
+import "react-photo-view/dist/react-photo-view.css";
 import createImageUrlBuilder from "@sanity/image-url";
 import { client } from "@/sanity/lib/client";
 import { type Image as SanityImage } from "sanity";
 
 interface SanityPhoto extends SanityImage {
-  caption?: string;
   alt?: string;
-  description?: string;
 }
 
 interface PhotoViewerProps {
   photos: SanityPhoto[];
-  initialIndex: number;
+  index: number;
+  visible: boolean;
   onClose: () => void;
-  title?: string; // album title (unused for now)
+  onIndexChange: (index: number) => void;
 }
 
-export default function PhotoViewer({
-  photos,
-  initialIndex,
-  onClose,
-}: PhotoViewerProps) {
-  const [currentIndex, setCurrentIndex] = useState(initialIndex);
-  const [isLoading, setIsLoading] = useState(true);
-  const touchStartX = useRef<number | null>(null);
-
+export default function PhotoViewer({ photos, index, visible, onClose, onIndexChange }: PhotoViewerProps) {
   const builder = createImageUrlBuilder(client);
-  function urlFor(source: SanityPhoto) {
-    return builder.image(source);
-  }
 
-  const navigateNext = useCallback(() => {
-    setIsLoading(true);
-    setCurrentIndex((prev) => (prev === photos.length - 1 ? 0 : prev + 1));
-  }, [photos.length]);
-
-  const navigatePrev = useCallback(() => {
-    setIsLoading(true);
-    setCurrentIndex((prev) => (prev === 0 ? photos.length - 1 : prev - 1));
-  }, [photos.length]);
-
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-      else if (e.key === "ArrowLeft") navigatePrev();
-      else if (e.key === "ArrowRight") navigateNext();
-    };
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [onClose, navigatePrev, navigateNext]);
-
-  useEffect(() => {
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, []);
-
-  useEffect(() => {
-    const handleTouchStart = (e: TouchEvent) => {
-      touchStartX.current = e.touches[0].clientX;
-    };
-    const handleTouchEnd = (e: TouchEvent) => {
-      if (touchStartX.current === null) return;
-      const deltaX = e.changedTouches[0].clientX - touchStartX.current;
-      if (Math.abs(deltaX) > 50) {
-        if (deltaX > 0) navigatePrev();
-        else navigateNext();
-      }
-    };
-    window.addEventListener("touchstart", handleTouchStart);
-    window.addEventListener("touchend", handleTouchEnd);
-    return () => {
-      window.removeEventListener("touchstart", handleTouchStart);
-      window.removeEventListener("touchend", handleTouchEnd);
-    };
-  }, [navigatePrev, navigateNext]);
-
-  useEffect(() => {
-    setIsLoading(true);
-  }, [currentIndex]);
-
-  const currentPhoto = photos[currentIndex];
+  const images = photos.map((p) => ({
+    src: builder.image(p).url() || "/placeholder.svg",
+    alt: p.alt ?? "",
+  }));
 
   return (
-    <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center bg-black">
-      {/* Close */}
-      <button
-        aria-label="Close photo viewer"
-        onClick={onClose}
-        className="absolute top-4 right-4 z-[110] rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70"
-      >
-        <X className="h-6 w-6" />
-      </button>
-
-
-      {/* Navigation */}
-      <button
-        aria-label="Previous photo"
-        onClick={navigatePrev}
-        className="absolute left-4 top-1/2 z-[110] -translate-y-1/2 rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70"
-      >
-        <ChevronLeft className="h-8 w-8" />
-      </button>
-      <button
-        aria-label="Next photo"
-        onClick={navigateNext}
-        className="absolute right-4 top-1/2 z-[110] -translate-y-1/2 rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70"
-      >
-        <ChevronRight className="h-8 w-8" />
-      </button>
-
-      {/* Image */}
-      <div className="relative flex h-full w-full items-center justify-center">
-        <div className="relative max-h-[90vh] max-w-[90vw]">
-          <Image
-            src={urlFor(currentPhoto).url() || "/placeholder.svg"}
-            alt={currentPhoto.alt ?? ""}
-            width={1200}
-            height={800}
-            priority
-            className={`max-h-[90vh] w-auto object-contain transition-opacity duration-300 ${
-              isLoading ? "opacity-0" : "opacity-100"
-            }`}
-            onLoad={() => setIsLoading(false)}
-          />
-
-        </div>
-      </div>
-
-      {/* Info below image */}
-      <div className="mt-4 text-center text-white">
-        <p className="text-sm mb-1 text-gray-300">
-          {currentIndex + 1} of {photos.length}
-        </p>
-        {currentPhoto.caption && (
-          <h3 className="text-lg font-semibold">{currentPhoto.caption}</h3>
-        )}
-        {currentPhoto.description && (
-          <p className="text-sm mt-1">{currentPhoto.description}</p>
-        )}
-      </div>
-    </div>
+    <PhotoProvider>
+      <PhotoSlider
+        images={images}
+        visible={visible}
+        onClose={onClose}
+        index={index}
+        onIndexChange={onIndexChange}
+      />
+    </PhotoProvider>
   );
 }

--- a/src/sanity/extract.json
+++ b/src/sanity/extract.json
@@ -508,21 +508,7 @@
                 },
                 "optional": true
               },
-              "caption": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
               "alt": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
-              "description": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string"
@@ -1013,13 +999,6 @@
                 "value": {
                   "type": "inline",
                   "name": "sanity.imageCrop"
-                },
-                "optional": true
-              },
-              "caption": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
                 },
                 "optional": true
               },

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -69,9 +69,7 @@ export const GALLERY_ALBUMS_QUERY = `*[_type == "album"] {
     asset->{url},
     hotspot,
     crop,
-    caption,
-    alt,
-    description
+    alt
   }
 }`;
 
@@ -86,8 +84,6 @@ export const ALBUM_BY_SLUG_QUERY = `*[_type == "album" && slug.current == $slug]
     asset->{url},
     hotspot,
     crop,
-    caption,
-    alt,
-    description
+    alt
   }
 }`;

--- a/src/sanity/schemaTypes/albumType.ts
+++ b/src/sanity/schemaTypes/albumType.ts
@@ -43,22 +43,10 @@ export const albumType = defineType({
           type: 'image',
           fields: [
             defineField({
-              name: 'caption',
-              title: 'Caption',
-              type: 'string',
-              description: 'Caption for the image',
-            }),
-            defineField({
               name: 'alt',
               title: 'Alt Text',
               type: 'string',
               description: 'Alternative text for accessibility',
-            }),
-            defineField({
-              name: 'description',
-              title: 'Image Description',
-              type: 'text',
-              description: 'Detailed description of the image',
             }),
           ],
         }),

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -99,9 +99,7 @@ export type Album = {
     media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
-    caption?: string;
     alt?: string;
-    description?: string;
     _type: "image";
     _key: string;
   }>;


### PR DESCRIPTION
## Summary
- update Sanity album image schema to only store alt text
- remove caption/description fields from generated types and schema extract
- switch GROQ queries to fetch only necessary image fields
- replace custom gallery components with `react-photo-view` based viewer
- show thumbnails on album page and open slider on click
- clean up old CSS for removed viewer
- **add `react-photo-view` dependency to package files**

## Testing
- `npm run lint` *(fails: Unexpected any and react/no-unescaped-entities errors)*
- `npm run build` *(fails due to network access required by sanity cli)*