### PR TITLE
Update toast placement and styling

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed right-0 top-16 z-[100] flex max-h-screen w-full flex-col space-y-2 p-4 md:max-w-[420px]",
       className
     )}
     {...props}
@@ -30,6 +30,8 @@ const toastVariants = cva(
     variants: {
       variant: {
         default: "border bg-background text-foreground",
+        success: "border-green-600 bg-green-600 text-white",
+        warning: "border-amber-500 bg-amber-500 text-white",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
       },


### PR DESCRIPTION
## Summary
- reposition toast viewport to appear below the navbar
- add success and warning variants for consistent toast colors

## Testing
- `npm run lint` *(fails: various existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6842f7ca3f2c832db1fdd851240ae14e