### PR TITLE
Add Vercel analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "next": "^15.3.2",
     "next-sanity": "^9.10.6",
     "next-themes": "^0.4.6",
+    "@vercel/analytics": "^1.2.0",
     "nodemailer": "^6.9.11",
     "react": "^18.2.0",
     "react-day-picker": "^9.6.7",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 import React from 'react';
 import type { Metadata } from 'next';
+import { Analytics } from '@vercel/analytics/react';
 import "./globals.css";
 
 // Define metadata for the root layout
@@ -27,6 +28,7 @@ export default function RootLayout({
       {/* No need to manually add <head> or <link rel="icon"> here */}
       <body>
         {children}
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- install the `@vercel/analytics` package in `package.json`
- integrate the Analytics component in the root `layout.tsx`

## Testing
- `npx next lint`
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails during sanity prebuild step)*

------
https://chatgpt.com/codex/tasks/task_b_68498dde1150832dbbc1939594cc09f3