### PR TITLE
Fix upcoming event query

### DIFF
--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -21,7 +21,7 @@ export const LATEST_EVENT_QUERY = defineQuery(`
     _type == "event" &&
     defined(slug.current) &&
     defined(eventDateTime) &&
-    coalesce(eventEndDateTime, eventDateTime) >= now()
+    eventDateTime >= now()
   ] | order(eventDateTime asc)[0]{
     _id,
     title,

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -17,7 +17,12 @@ export const POST_QUERY = defineQuery(`*[_type == "post" && slug.current == $slu
 }`)
 
 export const LATEST_EVENT_QUERY = defineQuery(`
-  *[_type == "event" && defined(slug.current) && defined(eventDateTime)] | order(eventDateTime desc)[0]{
+  *[
+    _type == "event" &&
+    defined(slug.current) &&
+    defined(eventDateTime) &&
+    coalesce(eventEndDateTime, eventDateTime) >= now()
+  ] | order(eventDateTime asc)[0]{
     _id,
     title,
     "slug": slug.current,

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -497,7 +497,7 @@ export type POST_QUERYResult = {
   } | null;
 } | null;
 // Variable: LATEST_EVENT_QUERY
-// Query: *[_type == "event" && defined(slug.current) && defined(eventDateTime)] | order(eventDateTime desc)[0]{    _id,    title,    "slug": slug.current,    eventDateTime,    eventEndDateTime,    location,    description,    mainImage,    "organizerName": organizer,    "timeDisplay": timeDisplay   }
+// Query: *[_type == "event" && defined(slug.current) && defined(eventDateTime) && coalesce(eventEndDateTime, eventDateTime) >= now()] | order(eventDateTime asc)[0]{    _id,    title,    "slug": slug.current,    eventDateTime,    eventEndDateTime,    location,    description,    mainImage,    "organizerName": organizer,    "timeDisplay": timeDisplay   }
 export type LATEST_EVENT_QUERYResult = {
   _id: string;
   title: string | null;
@@ -631,7 +631,7 @@ declare module "@sanity/client" {
   interface SanityQueries {
     "*[_type == \"post\" && defined(slug.current)] | order(publishedAt desc)[0...3]{\n  _id, title, slug, mainImage, publishedAt, body\n}": POSTS_QUERYResult;
     "*[_type == \"post\" && slug.current == $slug][0]{\n  title, body, mainImage\n}": POST_QUERYResult;
-    "\n  *[_type == \"event\" && defined(slug.current) && defined(eventDateTime)] | order(eventDateTime desc)[0]{\n    _id,\n    title,\n    \"slug\": slug.current,\n    eventDateTime,\n    eventEndDateTime,\n    location,\n    description,\n    mainImage,\n    \"organizerName\": organizer,\n    \"timeDisplay\": timeDisplay \n  }\n": LATEST_EVENT_QUERYResult;
+    "\n  *[_type == \"event\" && defined(slug.current) && defined(eventDateTime) && coalesce(eventEndDateTime, eventDateTime) >= now()] | order(eventDateTime asc)[0]{\n    _id,\n    title,\n    \"slug\": slug.current,\n    eventDateTime,\n    eventEndDateTime,\n    location,\n    description,\n    mainImage,\n    \"organizerName\": organizer,\n    \"timeDisplay\": timeDisplay \n  }\n": LATEST_EVENT_QUERYResult;
     "\n  *[_type == \"event\" && defined(slug.current)] | order(eventDateTime asc){\n    _id,\n    title,\n    \"slug\": slug.current,\n    eventDateTime,\n    eventEndDateTime,\n    location,\n    description,\n    mainImage,\n    \"organizerName\": organizer,\n    \"timeDisplay\": timeDisplay\n  }\n": ALL_EVENTS_QUERYResult;
     "\n  *[_type == \"event\" && slug.current == $slug][0]{\n    _id,\n    title,\n    \"slug\": slug.current, // Already stringified in event-card\n    eventDateTime,\n    eventEndDateTime,\n    timeDisplay,\n    location,\n    description, // Short description for cards\n    longDescription, // Detailed description\n    mainImage,\n    gallery,\n    features,\n    organizer,\n    contactEmail\n    // Add any other fields needed for the event details page\n  }\n": EVENT_BY_SLUG_QUERYResult;
   }

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -497,7 +497,7 @@ export type POST_QUERYResult = {
   } | null;
 } | null;
 // Variable: LATEST_EVENT_QUERY
-// Query: *[_type == "event" && defined(slug.current) && defined(eventDateTime) && coalesce(eventEndDateTime, eventDateTime) >= now()] | order(eventDateTime asc)[0]{    _id,    title,    "slug": slug.current,    eventDateTime,    eventEndDateTime,    location,    description,    mainImage,    "organizerName": organizer,    "timeDisplay": timeDisplay   }
+// Query: *[_type == "event" && defined(slug.current) && defined(eventDateTime) && eventDateTime >= now()] | order(eventDateTime asc)[0]{    _id,    title,    "slug": slug.current,    eventDateTime,    eventEndDateTime,    location,    description,    mainImage,    "organizerName": organizer,    "timeDisplay": timeDisplay   }
 export type LATEST_EVENT_QUERYResult = {
   _id: string;
   title: string | null;
@@ -631,7 +631,7 @@ declare module "@sanity/client" {
   interface SanityQueries {
     "*[_type == \"post\" && defined(slug.current)] | order(publishedAt desc)[0...3]{\n  _id, title, slug, mainImage, publishedAt, body\n}": POSTS_QUERYResult;
     "*[_type == \"post\" && slug.current == $slug][0]{\n  title, body, mainImage\n}": POST_QUERYResult;
-    "\n  *[_type == \"event\" && defined(slug.current) && defined(eventDateTime) && coalesce(eventEndDateTime, eventDateTime) >= now()] | order(eventDateTime asc)[0]{\n    _id,\n    title,\n    \"slug\": slug.current,\n    eventDateTime,\n    eventEndDateTime,\n    location,\n    description,\n    mainImage,\n    \"organizerName\": organizer,\n    \"timeDisplay\": timeDisplay \n  }\n": LATEST_EVENT_QUERYResult;
+    "\n  *[_type == \"event\" && defined(slug.current) && defined(eventDateTime) && eventDateTime >= now()] | order(eventDateTime asc)[0]{\n    _id,\n    title,\n    \"slug\": slug.current,\n    eventDateTime,\n    eventEndDateTime,\n    location,\n    description,\n    mainImage,\n    \"organizerName\": organizer,\n    \"timeDisplay\": timeDisplay \n  }\n": LATEST_EVENT_QUERYResult;
     "\n  *[_type == \"event\" && defined(slug.current)] | order(eventDateTime asc){\n    _id,\n    title,\n    \"slug\": slug.current,\n    eventDateTime,\n    eventEndDateTime,\n    location,\n    description,\n    mainImage,\n    \"organizerName\": organizer,\n    \"timeDisplay\": timeDisplay\n  }\n": ALL_EVENTS_QUERYResult;
     "\n  *[_type == \"event\" && slug.current == $slug][0]{\n    _id,\n    title,\n    \"slug\": slug.current, // Already stringified in event-card\n    eventDateTime,\n    eventEndDateTime,\n    timeDisplay,\n    location,\n    description, // Short description for cards\n    longDescription, // Detailed description\n    mainImage,\n    gallery,\n    features,\n    organizer,\n    contactEmail\n    // Add any other fields needed for the event details page\n  }\n": EVENT_BY_SLUG_QUERYResult;
   }


### PR DESCRIPTION
## Summary
- show the nearest upcoming event on the homepage instead of the farthest one

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run build` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685e7c0cfde0832d94eba797b3487694